### PR TITLE
Add base directory flag and .gitignore support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -150,6 +150,7 @@ dependencies = [
  "anyhow",
  "clap",
  "clipboard",
+ "gitignore",
  "glob",
  "tempfile",
  "walkdir",
@@ -180,6 +181,15 @@ dependencies = [
  "cfg-if",
  "libc",
  "wasi",
+]
+
+[[package]]
+name = "gitignore"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d051488d9a601181a9b90c9ad8ae7e8251d642ddd2463008f2f5019d255bd89"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ walkdir = "2.3"
 anyhow = "1.0"
 clap = { version = "4.4", features = ["derive"] }
 glob = "0.3"
+gitignore = "1.0.8"
 
 [dev-dependencies]
 tempfile = "3.3"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # dir_to_clipboard
 
-A fast and efficient command-line utility that copies directory contents and file contents to your clipboard. Bring your GPT up to speed with your codebase fast.
+A simple command-line utility that copies directory contents and file contents to your clipboard. Bring your GPT up to speed with your codebase fast.
 
 ## Features
 
@@ -12,6 +12,8 @@ A fast and efficient command-line utility that copies directory contents and fil
 - 🔍 File pattern filtering (e.g., `*.rs`, `*.txt`)
 - 📋 Direct clipboard integration
 - 🚀 Fast and memory efficient
+- ✅ Base directory selection with `--base-dir`
+- 🔓 `.gitignore` support for ignoring files (toggleable with `--no-ignore`)
 
 ## Installation
 
@@ -19,6 +21,12 @@ A fast and efficient command-line utility that copies directory contents and fil
 
 - Rust and Cargo (if building from source)
 - A clipboard-compatible system (macOS, Linux with X11)
+- **Linux users**: Install `xsel` for clipboard functionality:
+  ```bash
+  sudo pacman -S xsel  # Arch Linux
+  sudo apt-get install xsel  # Debian/Ubuntu
+  sudo yum install xsel  # Red Hat/CentOS
+  ```
 
 ### Building from Source
 
@@ -56,8 +64,14 @@ dir_to_clipboard --filter "*.rs"
 # Combine options
 dir_to_clipboard --recursive --filter "*.rs"
 
+# Set base directory
+dir_to_clipboard --base-dir /path/to/dir
+
+# Disable .gitignore filtering
+dir_to_clipboard --no-ignore
+
 # Short form
-dir_to_clipboard -r -f "*.rs"
+dir_to_clipboard -r -f "*.rs" -d /path/to/dir --no-ignore
 ```
 
 ### Output Format
@@ -74,12 +88,14 @@ The copied content will be formatted as follows:
 
 ### Command-line Options
 
-| Option | Short | Description |
-|--------|-------|-------------|
-| `--recursive` | `-r` | Recursively process subdirectories |
-| `--filter <PATTERN>` | `-f` | Filter files by pattern (e.g., "*.rs") |
-| `--help` | `-h` | Show help message |
-| `--version` | `-V` | Show version information |
+| Option              | Short | Description                                      |
+|---------------------|-------|--------------------------------------------------|
+| `--base-dir <DIR>`  | `-d`  | Set the base directory (default: current dir)   |
+| `--recursive`       | `-r`  | Recursively process subdirectories              |
+| `--filter <PATTERN>`| `-f`  | Filter files by pattern (e.g., "*.rs")          |
+| `--no-ignore`       |       | Disable `.gitignore` filtering                  |
+| `--help`            | `-h`  | Show help message                               |
+| `--version`         | `-V`  | Show version information                        |
 
 ## Smart Directory Handling
 
@@ -95,9 +111,9 @@ When using recursive mode with a filter:
 - `anyhow` - Error handling
 - `clap` - Command-line argument parsing
 - `glob` - File pattern matching
-
-### Dev Dependencieds
-- `tempfile` - to have some files in tests
+- `gitignore` - `.gitignore` file handling
+- `xsel` (Linux) - Clipboard management
+- `tempfile` - For tests
 
 ## Contributing
 
@@ -111,3 +127,4 @@ This project is licensed under the MIT License - see the LICENSE file for detail
 
 - The Rust community for excellent crates
 - Ferris the crab for being an awesome mascot 🦀;
+

--- a/src/main.rs
+++ b/src/main.rs
@@ -179,3 +179,119 @@ fn main() -> Result<()> {
 
     Ok(())
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs::{File, create_dir};
+    use std::io::Write;
+    use tempfile::tempdir;
+
+    #[test]
+    fn test_should_process_file_no_filter() {
+        let path = Path::new("example.rs");
+        assert!(should_process_file(path, None, None));
+    }
+
+    #[test]
+    fn test_should_process_file_with_matching_filter() {
+        let pattern = Pattern::new("*.rs").unwrap();
+        let path = Path::new("main.rs");
+        assert!(should_process_file(path, Some(&pattern), None));
+    }
+
+    #[test]
+    fn test_should_process_file_with_non_matching_filter() {
+        let pattern = Pattern::new("*.rs").unwrap();
+        let path = Path::new("main.txt");
+        assert!(!should_process_file(path, Some(&pattern), None));
+    }
+
+    #[test]
+    fn test_directory_has_matching_files() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.rs");
+        File::create(&file_path).unwrap();
+
+        let pattern = Pattern::new("*.rs").unwrap();
+        assert!(directory_has_matching_files(dir.path(), Some(&pattern), None));
+    }
+
+    #[test]
+    fn test_directory_has_no_matching_files() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("test.txt");
+        File::create(&file_path).unwrap();
+
+        let pattern = Pattern::new("*.rs").unwrap();
+        assert!(!directory_has_matching_files(dir.path(), Some(&pattern), None));
+    }
+
+    #[test]
+    fn test_read_file_contents() {
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("testfile.txt");
+        let mut file = File::create(&file_path).unwrap();
+        writeln!(file, "Hello, world!").unwrap();
+
+        let contents = read_file_contents(&file_path).unwrap();
+        assert_eq!(contents.trim(), "Hello, world!");
+    }
+
+    #[test]
+    fn test_read_file_contents_nonexistent_file() {
+        // Reading a non-existent file should return an error
+        let dir = tempdir().unwrap();
+        let file_path = dir.path().join("does_not_exist.txt");
+        let result = read_file_contents(&file_path);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_file_contents_directory_instead_of_file() {
+        // Reading a directory should return an error
+        let dir = tempdir().unwrap();
+        let result = read_file_contents(dir.path());
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_get_directory_listing_valid_path() {
+        let dir = tempdir().unwrap();
+        // Create a file so listing isn't empty
+        let file_path = dir.path().join("testfile.txt");
+        File::create(&file_path).unwrap();
+
+        // We expect some output (depends on OS, so just check non-empty success)
+        let listing = get_directory_listing(dir.path().to_str().unwrap());
+        assert!(listing.is_ok());
+        assert!(!listing.unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_directory_has_matching_files_subdir() {
+        let dir = tempdir().unwrap();
+
+        // create subdirectory
+        let sub_path = dir.path().join("sub");
+        create_dir(&sub_path).unwrap();
+
+        // create file in subdirectory
+        let file_path = sub_path.join("test.rs");
+        File::create(&file_path).unwrap();
+
+        // pattern
+        let pattern = Pattern::new("*.rs").unwrap();
+
+        // now check
+        assert!(directory_has_matching_files(dir.path(), Some(&pattern), None));
+    }
+
+    #[test]
+    fn test_invalid_filter_pattern() {
+        // An intentionally invalid pattern
+        let pattern = Pattern::new("[abc");
+        assert!(pattern.is_err());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,14 +2,19 @@ use anyhow::{Context, Result};
 use clap::Parser;
 use clipboard::{ClipboardContext, ClipboardProvider};
 use glob::Pattern;
+use gitignore::File as GitignoreFile;
 use std::fs;
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 use walkdir::WalkDir;
 
 #[derive(Parser)]
 #[command(author, version, about = "Copy directory contents to clipboard")]
 struct Args {
+    /// Base directory to start processing
+    #[arg(short, long, default_value = ".")]
+    base_dir: String,
+
     /// Recursively process subdirectories
     #[arg(short, long)]
     recursive: bool,
@@ -17,6 +22,14 @@ struct Args {
     /// Filter files by pattern (e.g., "*.rs")
     #[arg(short, long)]
     filter: Option<String>,
+
+    // Use xsel instead of the clipboard crate
+    #[arg(short, long, default_value = "false")]
+    x11: bool,
+
+    /// Ignore files specified in .gitignore
+    #[arg(long)]
+    no_ignore: bool,
 }
 
 fn get_directory_listing(path: &str) -> Result<String> {
@@ -25,17 +38,21 @@ fn get_directory_listing(path: &str) -> Result<String> {
         .arg(path)
         .output()
         .context("Failed to execute ls command")?;
-    
-    String::from_utf8(output.stdout)
-        .context("Failed to parse ls output")
+
+    String::from_utf8(output.stdout).context("Failed to parse ls output")
 }
 
 fn read_file_contents<P: AsRef<Path>>(path: P) -> Result<String> {
-    fs::read_to_string(path)
-        .context("Failed to read file")
+    fs::read_to_string(path).context("Failed to read file")
 }
 
-fn should_process_file(path: &Path, filter_pattern: Option<&Pattern>) -> bool {
+fn should_process_file(path: &Path, filter_pattern: Option<&Pattern>, gitignore: Option<&GitignoreFile>) -> bool {
+    if let Some(gitignore) = gitignore {
+        if gitignore.is_excluded(path).unwrap_or(false) {
+            return false;
+        }
+    }
+
     if let Some(pattern) = filter_pattern {
         if let Some(file_name) = path.file_name().and_then(|n| n.to_str()) {
             pattern.matches(file_name)
@@ -47,54 +64,84 @@ fn should_process_file(path: &Path, filter_pattern: Option<&Pattern>) -> bool {
     }
 }
 
-fn directory_has_matching_files(dir_path: &Path, filter_pattern: Option<&Pattern>) -> bool {
+fn directory_has_matching_files(
+    dir_path: &Path,
+    filter_pattern: Option<&Pattern>,
+    gitignore: Option<&GitignoreFile>,
+) -> bool {
     WalkDir::new(dir_path)
         .min_depth(1)
         .into_iter()
         .filter_map(|e| e.ok())
         .any(|entry| {
-            entry.file_type().is_file() && should_process_file(entry.path(), filter_pattern)
+            entry.file_type().is_file()
+                && should_process_file(entry.path(), filter_pattern, gitignore)
         })
+}
+
+fn copy_to_clipboard(contents: &str) -> Result<()> {
+    let mut process = Command::new("xsel")
+        .arg("-b")
+        .stdin(Stdio::piped())
+        .spawn()
+        .context("Failed to write clipboard")?;
+
+    if let Some(stdin) = process.stdin.as_mut() {
+        use std::io::Write;
+        stdin
+            .write_all(contents.as_bytes())
+            .context("Failed to write to xclip stdin")?;
+    }
+
+    process.wait().context("Failed to wait for xclip process")?;
+    Ok(())
 }
 
 fn main() -> Result<()> {
     let args = Args::parse();
-    
+
     // Convert filter pattern if provided
-    let filter_pattern = args.filter
+    let filter_pattern = args
+        .filter
         .as_ref()
         .map(|f| Pattern::new(f))
         .transpose()
         .context("Invalid filter pattern")?;
-    
-    // Initialize clipboard
+
     let mut ctx: ClipboardContext = ClipboardProvider::new()
         .map_err(|e| anyhow::anyhow!("Failed to initialize clipboard: {}", e))?;
-    
+
+    let gitignore_path = Path::new(&args.base_dir).join(Path::new(".gitignore"));
+    let gitignore = if args.no_ignore {
+        None
+    } else {
+        GitignoreFile::new(gitignore_path.as_path()).ok() // Ignore errors
+    };
+
     // Start building the output string
     let mut output = String::new();
-    
-    // Configure WalkDir based on recursive flag
-    let mut walker = WalkDir::new(".")
-        .min_depth(1);
-    
+
+    let mut walker = WalkDir::new(&args.base_dir).min_depth(1);
+
     if !args.recursive {
         walker = walker.max_depth(1);
     }
-    
-    // Keep track of current directory to avoid duplicate listings
+
     let mut current_dir: Option<String> = None;
-    
-    // Process all entries
+
     for entry in walker.into_iter().filter_map(|e| e.ok()) {
         let path = entry.path();
-        
-        if entry.file_type().is_file() && should_process_file(path, filter_pattern.as_ref()) {
+
+        if entry.file_type().is_file()
+            && should_process_file(path, filter_pattern.as_ref(), gitignore.as_ref())
+        {
             // If we're in a new directory that contains matching files, add its listing
             let dir_path = path.parent().unwrap().to_string_lossy().to_string();
             if current_dir.as_ref() != Some(&dir_path) {
                 // For recursive mode, check if directory has matching files
-                if !args.recursive || directory_has_matching_files(Path::new(&dir_path), filter_pattern.as_ref()) {
+                if !args.recursive
+                    || directory_has_matching_files(Path::new(&dir_path), filter_pattern.as_ref(), gitignore.as_ref())
+                {
                     output.push_str(&format!("\n=== Directory: {} ===\n", dir_path));
                     if let Ok(listing) = get_directory_listing(&dir_path) {
                         output.push_str(&listing);
@@ -102,7 +149,7 @@ fn main() -> Result<()> {
                     current_dir = Some(dir_path);
                 }
             }
-            
+
             // Add file contents
             if let Ok(contents) = read_file_contents(path) {
                 output.push_str(&format!("\n=== File: {} ===\n", path.display()));
@@ -111,13 +158,17 @@ fn main() -> Result<()> {
             }
         }
     }
-    
+
     // Copy to clipboard
-    ctx.set_contents(output)
-        .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
-    
+    if args.x11 {
+        copy_to_clipboard(&output)?;
+    } else {
+        ctx.set_contents(output)
+            .map_err(|e| anyhow::anyhow!("Failed to set clipboard contents: {}", e))?;
+    }
+
     println!("Directory contents and file contents have been copied to clipboard!");
-    
+
     // Print summary of what was processed
     if let Some(pattern) = &args.filter {
         println!("Filtered files using pattern: {}", pattern);
@@ -125,121 +176,6 @@ fn main() -> Result<()> {
     if args.recursive {
         println!("Processed subdirectories recursively (showing only directories with matching files)");
     }
-    
+
     Ok(())
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::fs::{File, create_dir};
-    use std::io::Write;
-    use tempfile::tempdir;
-
-    #[test]
-    fn test_should_process_file_no_filter() {
-        let path = Path::new("example.rs");
-        assert!(should_process_file(path, None));
-    }
-
-    #[test]
-    fn test_should_process_file_with_matching_filter() {
-        let pattern = Pattern::new("*.rs").unwrap();
-        let path = Path::new("main.rs");
-        assert!(should_process_file(path, Some(&pattern)));
-    }
-
-    #[test]
-    fn test_should_process_file_with_non_matching_filter() {
-        let pattern = Pattern::new("*.rs").unwrap();
-        let path = Path::new("main.txt");
-        assert!(!should_process_file(path, Some(&pattern)));
-    }
-
-    #[test]
-    fn test_directory_has_matching_files() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("test.rs");
-        File::create(&file_path).unwrap();
-
-        let pattern = Pattern::new("*.rs").unwrap();
-        assert!(directory_has_matching_files(dir.path(), Some(&pattern)));
-    }
-
-    #[test]
-    fn test_directory_has_no_matching_files() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("test.txt");
-        File::create(&file_path).unwrap();
-
-        let pattern = Pattern::new("*.rs").unwrap();
-        assert!(!directory_has_matching_files(dir.path(), Some(&pattern)));
-    }
-
-    #[test]
-    fn test_read_file_contents() {
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("testfile.txt");
-        let mut file = File::create(&file_path).unwrap();
-        writeln!(file, "Hello, world!").unwrap();
-
-        let contents = read_file_contents(&file_path).unwrap();
-        assert_eq!(contents.trim(), "Hello, world!");
-    }
-
-    #[test]
-    fn test_read_file_contents_nonexistent_file() {
-        // Reading a non-existent file should return an error
-        let dir = tempdir().unwrap();
-        let file_path = dir.path().join("does_not_exist.txt");
-        let result = read_file_contents(&file_path);
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_read_file_contents_directory_instead_of_file() {
-        // Reading a directory should return an error
-        let dir = tempdir().unwrap();
-        let result = read_file_contents(dir.path());
-        assert!(result.is_err());
-    }
-
-    #[test]
-    fn test_get_directory_listing_valid_path() {
-        let dir = tempdir().unwrap();
-        // Create a file so listing isn't empty
-        let file_path = dir.path().join("testfile.txt");
-        File::create(&file_path).unwrap();
-
-        // We expect some output (depends on OS, so just check non-empty success)
-        let listing = get_directory_listing(dir.path().to_str().unwrap());
-        assert!(listing.is_ok());
-        assert!(!listing.unwrap().is_empty());
-    }
-
-    #[test]
-    fn test_directory_has_matching_files_subdir() {
-        let dir = tempdir().unwrap();
-
-        // create subdirectory
-        let sub_path = dir.path().join("sub");
-        create_dir(&sub_path).unwrap();
-
-        // create file in subdirectory
-        let file_path = sub_path.join("test.rs");
-        File::create(&file_path).unwrap();
-
-        // pattern
-        let pattern = Pattern::new("*.rs").unwrap();
-
-        // now check
-        assert!(directory_has_matching_files(dir.path(), Some(&pattern)));
-    }
-
-    #[test]
-    fn test_invalid_filter_pattern() {
-        // An intentionally invalid pattern
-        let pattern = Pattern::new("[abc");
-        assert!(pattern.is_err());
-    }
 }


### PR DESCRIPTION
- Added an --x11/-x flag for compatability with xserver. This requires the clipboard manager `xsel` to be installed (default false).
- Introduced `--base-dir/-b` flag to set a custom base directory (default: current directory).
- Added support for respecting `.gitignore` files, with the ability to disable via `--no-ignore`.
- Updated README with new features, usage examples, and Linux `xsel` dependency information.